### PR TITLE
fix typo in lexical argument to preprocess_multiwoz.py

### DIFF
--- a/create_dataset.sh
+++ b/create_dataset.sh
@@ -3,7 +3,7 @@
 python preprocess_multiwoz.py delex
 
 # preprocess multiwoz with lexicalized responses
-python preprocess_multiwoz.py lexixal
+python preprocess_multiwoz.py lexical
 
 # create dataset for language modeling with SimpleTOD
 python prepare_simpletod_data.py


### PR DESCRIPTION
There's a typo in the create_data.sh that causes the script to error. Let's fix it! 